### PR TITLE
Make inline code's font size better

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -632,8 +632,8 @@ blockquote {
 
 code {
   font-family: "Lucida Sans", Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
+  font-size-adjust: 0.55;
   color: #efefef;
-  font-size: 13px;
   margin: 0 4px;
   padding: 4px 6px;
   -webkit-border-radius: 2px;
@@ -660,6 +660,8 @@ pre {
 }
 pre code {
   color: #efefef;
+  font-size: 13px;
+  font-size-adjust: none;
   text-shadow: 0px 1px 0px #000;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
In [option docs for YouCompleteMe](http://valloric.github.io/YouCompleteMe/#options), headings generally don't look like headings because they mainly consist of option names in `<code>`, which are rendered quite small (at least on Chromium). Body text has the same issue, though this affects only aesthestics, not comprehension.

This patch leaves code blocks at the smaller size (which seems fine, although they could also be made larger to match highlit code) and adjusts inline code to match the size of the surounding paragraph.

Caveats:
- The font-size-adjust value was arrived at by experimentation (which seems to be the approach recommended by the spec), and I'm not sure how well it generalizes. The fonts rendered on my system are "OTS derived font" (not sure what this is?) and Consolas.
- I'm not sure how other Midnight-themed pages use `<code>`.
